### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "tailwind-variants": "^0.3.0",
     "tiny-invariant": "^1.3.3",
     "use-debounce": "^10.0.4",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "validator": "^13.12.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",

--- a/server/routes/pigs.js
+++ b/server/routes/pigs.js
@@ -3,6 +3,7 @@ const router = express.Router()
 const Pig = require('../models/Pig')
 const BCSData = require('../models/BCSData')
 const PostureData = require('../models/PostureData')
+const validator = require('validator')
 
 // Get all pigs
 router.get('/', async (req, res) => {
@@ -84,12 +85,17 @@ router.get('/:id/posture', async (req, res) => {
 router.put('/:id', async (req, res) => {
   try {
     const pigId = parseInt(req.params.id)
-    const updates = {
-      breed: req.body.breed,
-      age: parseInt(req.body.age),
-      groupId: parseInt(req.body.group),
-      lastUpdate: new Date()
+    const updates = {}
+    if (req.body.breed && validator.isAlpha(req.body.breed)) {
+      updates.breed = req.body.breed
     }
+    if (req.body.age && validator.isInt(req.body.age)) {
+      updates.age = parseInt(req.body.age)
+    }
+    if (req.body.group && validator.isInt(req.body.group)) {
+      updates.groupId = parseInt(req.body.group)
+    }
+    updates.lastUpdate = new Date()
     
     const updatedPig = await Pig.findOneAndUpdate(
       { pigId },

--- a/server/routes/pigs.js
+++ b/server/routes/pigs.js
@@ -86,20 +86,20 @@ router.put('/:id', async (req, res) => {
   try {
     const pigId = parseInt(req.params.id)
     const updates = {}
-    if (req.body.breed && validator.isAlpha(req.body.breed)) {
-      updates.breed = req.body.breed
+    if (req.body.breed && validator.isAlpha(req.body.breed, 'en-US', { ignore: ' ' })) {
+      updates.breed = req.body.breed.trim()
     }
-    if (req.body.age && validator.isInt(req.body.age)) {
-      updates.age = parseInt(req.body.age)
+    if (req.body.age && validator.isInt(req.body.age, { min: 0 })) {
+      updates.age = parseInt(req.body.age, 10)
     }
-    if (req.body.group && validator.isInt(req.body.group)) {
-      updates.groupId = parseInt(req.body.group)
+    if (req.body.group && validator.isInt(req.body.group, { min: 0 })) {
+      updates.groupId = parseInt(req.body.group, 10)
     }
     updates.lastUpdate = new Date()
     
     const updatedPig = await Pig.findOneAndUpdate(
       { pigId },
-      updates,
+      { $set: updates },
       { new: true }
     )
 


### PR DESCRIPTION
Potential fix for [https://github.com/brodynelly/paal-test/security/code-scanning/2](https://github.com/brodynelly/paal-test/security/code-scanning/2)

To fix the problem, we need to ensure that the user-provided values in `req.body` are properly sanitized and validated before being used in the database query. This can be achieved by using a library like `validator` to validate and sanitize the input values. Additionally, we should ensure that the `updates` object only contains valid fields that are expected by the database schema.

1. Install the `validator` library to help with input validation and sanitization.
2. Validate and sanitize each field in `req.body` before constructing the `updates` object.
3. Ensure that only valid fields are included in the `updates` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
