### PR TITLE
Potential fix for code scanning alert no. 22: Database query built from user-controlled sources

### DIFF
--- a/server/routes/pig.js
+++ b/server/routes/pig.js
@@ -165,16 +165,23 @@ router.get('/:id/posture', async (req, res) => {
 router.put('/:id', async (req, res) => {
   try {
     const pigId = parseInt(req.params.id)
-    const updates = {
-      breed: req.body.breed,
-      age: parseInt(req.body.age),
-      groupId: parseInt(req.body.group),
-      lastUpdate: new Date()
+    
+    // Validate and sanitize req.body fields
+    const updates = {}
+    if (typeof req.body.breed === 'string') {
+      updates.breed = req.body.breed
     }
+    if (!isNaN(parseInt(req.body.age))) {
+      updates.age = parseInt(req.body.age)
+    }
+    if (!isNaN(parseInt(req.body.group))) {
+      updates.groupId = parseInt(req.body.group)
+    }
+    updates.lastUpdate = new Date()
     
     const updatedPig = await Pig.findOneAndUpdate(
       { pigId },
-      updates,
+      { $set: updates },
       { new: true }
     )
 


### PR DESCRIPTION
Potential fix for [https://github.com/brodynelly/paal-test/security/code-scanning/22](https://github.com/brodynelly/paal-test/security/code-scanning/22)

To fix the problem, we need to ensure that the user-provided data in `req.body` is properly validated and sanitized before being used in the database query. We can achieve this by:
1. Validating the types and values of the fields in `req.body`.
2. Using the `$set` operator in the MongoDB query to ensure that only the specified fields are updated.

We will modify the code in `server/routes/pig.js` to include validation for the `req.body` fields and use the `$set` operator in the `findOneAndUpdate` query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
