### PR TITLE
Potential fix for code scanning alert no. 552: Missing rate limiting

### DIFF
--- a/server/routes/pig.js
+++ b/server/routes/pig.js
@@ -6,6 +6,16 @@ const BCSData = require('../models/BCSData')
 const PostureData = require('../models/PostureData')
 const PigFertility = require('../models/PigFertility');
 const PigHeatStatus = require('../models/PigHeatStatus');
+const rateLimit = require('express-rate-limit');
+
+// Define rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+// Apply rate limiter to all requests
+router.use(limiter);
 
 // Get all pigs
 router.get('/', async (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/brodynelly/paal-test/security/code-scanning/552](https://github.com/brodynelly/paal-test/security/code-scanning/552)

To fix the problem, we need to introduce rate limiting to the route handlers in the `server/routes/pig.js` file. The best way to do this is by using the `express-rate-limit` middleware. This middleware allows us to define a maximum number of requests that a client can make within a specified time window. We will apply this middleware to the router to ensure that all routes are protected.

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the `server/routes/pig.js` file.
3. Define a rate limiter with appropriate settings (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the router.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
