### PR TITLE
Potential fix for code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/server/routes/devices.js
+++ b/server/routes/devices.js
@@ -241,10 +241,17 @@ router.post('/', async (req, res) => {
 router.put('/:id', async (req, res) => {
   try {
     const deviceId = parseInt(req.params.id)
+    
+    // Validate req.body values
+    const { deviceName, deviceType, status } = req.body;
+    if (typeof deviceName !== 'string' || typeof deviceType !== 'string' || typeof status !== 'string') {
+      return res.status(400).json({ error: 'Invalid input data' });
+    }
+    
     const updates = {
-      deviceName: req.body.deviceName,
-      deviceType: req.body.deviceType,
-      status: req.body.status,
+      deviceName,
+      deviceType,
+      status,
       lastUpdate: new Date()
     }
     


### PR DESCRIPTION
Potential fix for [https://github.com/brodynelly/paal-test/security/code-scanning/1](https://github.com/brodynelly/paal-test/security/code-scanning/1)

To fix the problem, we need to ensure that the user-provided data in `req.body` is properly sanitized or validated before being used in the database query. One way to achieve this is by using a library like `mongoose` to validate the data types and structure. Alternatively, we can manually validate the data to ensure it meets the expected criteria.

The best way to fix this problem without changing existing functionality is to validate the `req.body` values before constructing the `updates` object. We will check that the values are of the expected types (e.g., strings for `deviceName` and `deviceType`, and a valid status value).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
