### PR TITLE
Potential fix for code scanning alert no. 18: Database query built from user-controlled sources

### DIFF
--- a/server/routes/barn.js
+++ b/server/routes/barn.js
@@ -35,6 +35,10 @@ router.get('/:id', async (req, res) => {
 // CREATE barn
 router.post('/', async (req, res) => {
   try {
+    // Validate input
+    if (typeof req.body.name !== 'string' || typeof req.body.description !== 'string' || typeof req.body.farmId !== 'string') {
+      return res.status(400).json({ error: 'Invalid input' });
+    }
     const newBarn = await Barn.create({
       name: req.body.name,
       description: req.body.description,
@@ -50,13 +54,17 @@ router.post('/', async (req, res) => {
 // UPDATE barn
 router.put('/:id', async (req, res) => {
   try {
+    // Validate input
+    if (typeof req.body.name !== 'string' || typeof req.body.description !== 'string' || typeof req.body.farmId !== 'string') {
+      return res.status(400).json({ error: 'Invalid input' });
+    }
     const updatedBarn = await Barn.findByIdAndUpdate(
       req.params.id,
-      {
+      { $set: {
         name: req.body.name,
         description: req.body.description,
         farmId: req.body.farmId
-      },
+      }},
       { new: true }
     )
     if (!updatedBarn) {


### PR DESCRIPTION
Potential fix for [https://github.com/brodynelly/paal-test/security/code-scanning/18](https://github.com/brodynelly/paal-test/security/code-scanning/18)

To fix the problem, we need to ensure that the user-provided data is sanitized or validated before being used in the database query. For NoSQL databases like MongoDB, we can use the `$set` operator to ensure that the user input is interpreted as a literal value and not as a query object. Additionally, we should validate the input to ensure it meets the expected format and type.

1. Use the `$set` operator in the `Barn.findByIdAndUpdate` method to safely update the fields.
2. Validate the user input to ensure it is of the expected type and format before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
