### PR TITLE
Potential fix for code scanning alert no. 562: Missing rate limiting

### DIFF
--- a/server/routes/farm.js
+++ b/server/routes/farm.js
@@ -6,9 +6,16 @@ const Barn = require('../models/Barn')
 const Stall = require('../models/Stall')
 const Device = require('../models/Device')
 const Pig = require('../models/Pig') // if pigs are associated at the farm level or indirectly through barns/stalls
+const rateLimit = require('express-rate-limit')
+
+// Rate limiter middleware
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+})
 
 // GET all farms
-router.get('/', async (req, res) => {
+router.get('/', limiter, async (req, res) => {
   try {
     const farms = await Farm.find({})
       .populate('barns') // if you want to see associated barn data
@@ -21,7 +28,7 @@ router.get('/', async (req, res) => {
 })
 
 // GET single farm
-router.get('/:id', async (req, res) => {
+router.get('/:id', limiter, async (req, res) => {
   try {
     const farm = await Farm.findById(req.params.id)
       .populate('barns')
@@ -36,7 +43,7 @@ router.get('/:id', async (req, res) => {
 })
 
 // CREATE new farm
-router.post('/', async (req, res) => {
+router.post('/', limiter, async (req, res) => {
   try {
     const newFarm = await Farm.create({
       name: req.body.name,
@@ -51,7 +58,7 @@ router.post('/', async (req, res) => {
 })
 
 // UPDATE farm
-router.put('/:id', async (req, res) => {
+router.put('/:id', limiter, async (req, res) => {
   try {
     // Validate input
     const { name, location } = req.body;
@@ -75,7 +82,7 @@ router.put('/:id', async (req, res) => {
 })
 
 // DELETE farm
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', limiter, async (req, res) => {
   try {
     const result = await Farm.findByIdAndDelete(req.params.id)
     if (!result) {


### PR DESCRIPTION
Potential fix for [https://github.com/brodynelly/paal-test/security/code-scanning/562](https://github.com/brodynelly/paal-test/security/code-scanning/562)

To fix the problem, we need to introduce a rate-limiting middleware to the Express application. The `express-rate-limit` package is a well-known library that can be used for this purpose. We will set up a rate limiter that restricts the number of requests a client can make within a specified time window. This will help mitigate the risk of DoS attacks by limiting the rate at which requests are accepted.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server/routes/farm.js` file.
3. Set up a rate limiter with a reasonable configuration (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to the routes that perform database access operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
