### PR TITLE
Potential fix for code scanning alert no. 582: Database query built from user-controlled sources

### DIFF
--- a/server/routes/pig.js
+++ b/server/routes/pig.js
@@ -290,8 +290,13 @@ router.post('/', async (req, res) => {
   try {
     const { pigId, tag, breed, age, currentLocation } = req.body
     
+    // Validate pigId
+    if (typeof pigId !== 'string' && typeof pigId !== 'number') {
+      return res.status(400).json({ error: 'Invalid pigId' })
+    }
+    
     // Check if pig with this ID already exists
-    const existingPig = await Pig.findOne({ pigId: pigId })
+    const existingPig = await Pig.findOne({ pigId: { $eq: pigId } })
     if (existingPig) {
       return res.status(400).json({ error: 'Pig with this ID already exists' })
     }


### PR DESCRIPTION
Potential fix for [https://github.com/brodynelly/paal/security/code-scanning/582](https://github.com/brodynelly/paal/security/code-scanning/582)

To fix the problem, we need to ensure that the `pigId` is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. Additionally, we should validate that `pigId` is of the expected type (e.g., a string or number) before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
