### PR TITLE
Remove unused helper from barn routes

### DIFF
--- a/server/routes/barn.js
+++ b/server/routes/barn.js
@@ -158,27 +158,6 @@ router.get('/capacity', async (req, res) => {
     });
   }
 });
-// Reuse the same calculateDateRange function from farms.js
-function calculateDateRange(range) {
-  const now = new Date();
-  let startDate = new Date();
-  
-  switch(range) {
-      case '30-days':
-          startDate.setDate(now.getDate() - 30);
-          break;
-      case '90-days':
-          startDate.setDate(now.getDate() - 90);
-          break;
-      case '180-days':
-          startDate.setDate(now.getDate() - 180);
-          break;
-      default: // 365-days
-          startDate.setDate(now.getDate() - 365);
-  }
-  
-  return { start: startDate };
-}
 
 // GET barns by farm ID
 router.get('/farm/:id', async (req, res) => {


### PR DESCRIPTION
## Summary
- delete dead `calculateDateRange` helper from `barn.js`

## Testing
- `npm test` *(fails: Missing script)*
- `pnpm test` *(fails: could not download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68539e9de0cc8324b5b584fc663245a4