### PR TITLE
Improve cascade deletion check for farms

### DIFF
--- a/server/routes/farm.js
+++ b/server/routes/farm.js
@@ -259,13 +259,31 @@ router.put('/:id', authenticateJWT, isAdmin, async (req, res) => {
 router.delete('/:id', authenticateJWT, isAdmin, async (req, res) => {
   try {
     const { cascade } = req.query; // Add ?cascade=true to delete associated data
-    
+
     const farm = await Farm.findById(req.params.id);
     if (!farm) {
       return res.status(404).json({ error: 'Farm not found' });
     }
-    
-    // If cascade is true, delete all associated data
+
+    // Count related documents to check for orphans
+    const [barns, stalls, pigs, devices] = await Promise.all([
+      Barn.countDocuments({ farmId: farm._id }),
+      Stall.countDocuments({ farmId: farm._id }),
+      Pig.countDocuments({ 'currentLocation.farmId': farm._id }),
+      Device.countDocuments({ farmId: farm._id })
+    ]);
+
+    const hasRelations = barns + stalls + pigs + devices > 0;
+
+    // If there are related docs and cascade flag is not true, refuse deletion
+    if (hasRelations && cascade !== 'true') {
+      return res.status(400).json({
+        error:
+          'Farm has related barns, stalls, pigs or devices. Use ?cascade=true to delete them as well.'
+      });
+    }
+
+    // Cascade deletion when requested
     if (cascade === 'true') {
       await Promise.all([
         Barn.deleteMany({ farmId: farm._id }),
@@ -274,9 +292,9 @@ router.delete('/:id', authenticateJWT, isAdmin, async (req, res) => {
         Device.deleteMany({ farmId: farm._id })
       ]);
     }
-    
+
     await Farm.findByIdAndDelete(req.params.id);
-    
+
     res.json({ message: 'Farm deleted successfully' });
   } catch (error) {
     console.error('Error deleting farm:', error);


### PR DESCRIPTION
## Summary
- update farm deletion API to block removal when related data exists unless `cascade=true`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539d4012c8832481813c57cfb1f357