### PR TITLE
Enforce cascade option when deleting farms

### DIFF
--- a/documentation/backend/api-design.md
+++ b/documentation/backend/api-design.md
@@ -1044,7 +1044,7 @@ Deletes a farm (admin only).
 - **Auth Required**: Yes (Admin)
 
 **Query Parameters**:
-- `cascade` (optional): If "true", deletes all associated barns, stalls, and pigs
+- `cascade` (required): Must be "true" to delete a farm. When provided, all associated barns, stalls, pigs, and devices are also deleted
 
 **Success Response (200 OK)**:
 ```json
@@ -1054,6 +1054,7 @@ Deletes a farm (admin only).
 ```
 
 **Error Responses**:
+- `400 Bad Request`: `cascade=true` not supplied
 - `401 Unauthorized`: Not authenticated
 - `403 Forbidden`: Not authorized as admin
 - `404 Not Found`: Farm not found

--- a/server/routes/farm.js
+++ b/server/routes/farm.js
@@ -259,24 +259,30 @@ router.put('/:id', authenticateJWT, isAdmin, async (req, res) => {
 router.delete('/:id', authenticateJWT, isAdmin, async (req, res) => {
   try {
     const { cascade } = req.query; // Add ?cascade=true to delete associated data
-    
+
     const farm = await Farm.findById(req.params.id);
     if (!farm) {
       return res.status(404).json({ error: 'Farm not found' });
     }
-    
-    // If cascade is true, delete all associated data
-    if (cascade === 'true') {
-      await Promise.all([
-        Barn.deleteMany({ farmId: farm._id }),
-        Stall.deleteMany({ farmId: farm._id }),
-        Pig.deleteMany({ 'currentLocation.farmId': farm._id }),
-        Device.deleteMany({ farmId: farm._id })
-      ]);
+
+    // Require cascade flag to avoid orphaned resources
+    if (cascade !== 'true') {
+      return res.status(400).json({
+        error:
+          'Deleting a farm without cascade=true would orphan related resources.'
+      });
     }
-    
+
+    // Delete all associated data when cascade=true
+    await Promise.all([
+      Barn.deleteMany({ farmId: farm._id }),
+      Stall.deleteMany({ farmId: farm._id }),
+      Pig.deleteMany({ 'currentLocation.farmId': farm._id }),
+      Device.deleteMany({ farmId: farm._id })
+    ]);
+
     await Farm.findByIdAndDelete(req.params.id);
-    
+
     res.json({ message: 'Farm deleted successfully' });
   } catch (error) {
     console.error('Error deleting farm:', error);

--- a/src/app/(main)/system-overview/overview/FarmerManagementDrawer.tsx
+++ b/src/app/(main)/system-overview/overview/FarmerManagementDrawer.tsx
@@ -285,7 +285,7 @@ const FirstPage = ({
                 variant="ghost"
                 className="p-2 text-gray-500 hover:bg-red-50 hover:text-red-500 dark:text-gray-500 hover:dark:text-gray-300"
                 onClick={async () => {
-                  await deleteEntity("farms", selectedFarmId)
+                  await deleteEntity("farms", selectedFarmId, true)
                   setSelectedFarmId(null)
                   refreshData()
                 }}


### PR DESCRIPTION
## Summary
- refuse to delete a farm unless `cascade=true` is provided
- update deletion UI to include cascade flag
- document the new requirement for farm deletion

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68539d4012c8832481813c57cfb1f357