### PR TITLE
Fix admin check in register route

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -19,11 +19,7 @@ const loginLimiter = rateLimit({
 // Register a new user (admin only)
 router.post('/register', authenticateJWT, isAdmin, async (req, res) => {
   try {
-    // Check if requester is admin
-    if (req.user.role !== 'admin') {
-      return res.status(403).json({ error: 'Only admins can register new users' });
-    }
-
+    // Authorization handled by isAdmin middleware
     const {
       email,
       password,


### PR DESCRIPTION
## Summary
- remove admin check inside `/register` route in `auth.js` because `isAdmin` middleware already covers it

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68539d13426c8324b4508cee5bf40521