### PR TITLE
Fix barn delete cascade

### DIFF
--- a/server/routes/barn.js
+++ b/server/routes/barn.js
@@ -296,16 +296,19 @@ router.delete('/:id', async (req, res) => {
       return res.status(404).json({ error: 'Barn not found' })
     }
 
-    if (cascade === 'true') {
-      // Cascade delete - remove associated stalls and update pigs
-      await Promise.all([
-        Stall.deleteMany({ barnId: barn._id }),
-        Pig.updateMany(
-          { 'currentLocation.barnId': barn._id },
-          { $set: { 'currentLocation.barnId': null } }
-        )
-      ])
+    // If cascade query is provided but not explicitly true, refuse deletion
+    if (cascade && cascade !== 'true') {
+      return res.status(400).json({ error: 'Cascade must be true to delete a barn' })
     }
+
+    // Always clean up associated data so no references remain
+    await Promise.all([
+      Stall.deleteMany({ barnId: barn._id }),
+      Pig.updateMany(
+        { 'currentLocation.barnId': barn._id },
+        { $set: { 'currentLocation.barnId': null, 'currentLocation.stallId': null } }
+      )
+    ])
 
     await barn.deleteOne()
     res.json({ message: 'Barn deleted successfully' })


### PR DESCRIPTION
## Summary
- handle barns' associated stalls and pigs even when cascade isn't explicitly enabled

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e0fd940083248cbeb4940cfaf0e0