### PR TITLE
Remove unused helper from stall route

### DIFF
--- a/server/routes/stall.js
+++ b/server/routes/stall.js
@@ -145,28 +145,6 @@ router.get('/health', async (req, res) => {
   }
 });
 
-// Reuse the same calculateDateRange function
-function calculateDateRange(range) {
-  const now = new Date();
-  let startDate = new Date();
-  
-  switch(range) {
-      case '30-days':
-          startDate.setDate(now.getDate() - 30);
-          break;
-      case '90-days':
-          startDate.setDate(now.getDate() - 90);
-          break;
-      case '180-days':
-          startDate.setDate(now.getDate() - 180);
-          break;
-      default: // 365-days
-          startDate.setDate(now.getDate() - 365);
-  }
-  
-  return { start: startDate };
-}
-
 
 // GET single stall with detailed info
 router.get('/:id', async (req, res) => {


### PR DESCRIPTION
## Summary
- remove `calculateDateRange` helper from `stall.js`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e118fd588324a82009f9ee89b944