### PR TITLE
Fix device routes by removing invalid pig lookup

### DIFF
--- a/server/routes/devices.js
+++ b/server/routes/devices.js
@@ -213,16 +213,7 @@ router.get('/:id/temperature', async (req, res) => {
   }
 })
 
-// Get associated pig for device
-router.get('/:id/pig', async (req, res) => {
-  try {
-    const pig = await Pig.findOne({ deviceId: parseInt(req.params.id) })
-    res.json({ pigId: pig?.pigId || null })
-  } catch (error) {
-    console.error('Error fetching associated pig:', error)
-    res.status(500).json({ error: 'Failed to fetch associated pig' })
-  }
-})
+// Route removed: devices are not directly linked to pigs
 
 // Create new device
 router.post('/', async (req, res) => {


### PR DESCRIPTION
## Summary
- remove old `/devices/:id/pig` endpoint since devices and pigs aren't linked

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854e181434483249e731d8aa241cc2c