### PR TITLE
Add numeric validation for temperature routes

### DIFF
--- a/server/routes/temperatureData.js
+++ b/server/routes/temperatureData.js
@@ -47,10 +47,17 @@ router.post('/', async (req, res) => {
     const lastRecord = await TemperatureData.findOne().sort({ recordId: -1 })
     const newRecordId = (lastRecord?.recordId || 0) + 1
 
+    const deviceId = parseInt(req.body.deviceId)
+    const temperature = parseFloat(req.body.temperature)
+
+    if (isNaN(deviceId) || !Number.isFinite(temperature)) {
+      return res.status(400).json({ error: 'Invalid deviceId or temperature' })
+    }
+
     const newRecord = await TemperatureData.create({
       recordId: newRecordId,
-      deviceId: parseInt(req.body.deviceId),
-      temperature: parseFloat(req.body.temperature),
+      deviceId,
+      temperature,
       timestamp: req.body.timestamp || new Date()
     })
 
@@ -65,9 +72,16 @@ router.post('/', async (req, res) => {
 router.put('/:recordId', async (req, res) => {
   try {
     const recordId = parseInt(req.params.recordId)
+    const deviceId = parseInt(req.body.deviceId)
+    const temperature = parseFloat(req.body.temperature)
+
+    if (isNaN(deviceId) || !Number.isFinite(temperature)) {
+      return res.status(400).json({ error: 'Invalid deviceId or temperature' })
+    }
+
     const updates = {
-      deviceId: parseInt(req.body.deviceId),
-      temperature: parseFloat(req.body.temperature),
+      deviceId,
+      temperature,
       timestamp: req.body.timestamp ? new Date(req.body.timestamp) : new Date()
     }
     


### PR DESCRIPTION
## Summary
- validate `deviceId` and `temperature` when creating or updating temperature data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e29c7b4083248f62a57d3963a3bf