### PR TITLE
Fix posture distribution reducer

### DIFF
--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -83,7 +83,7 @@ router.get('/', async (req, res) => {
 
     // Calculate posture stats
     const postureCounts = postureData.reduce((acc, curr) => {
-      acc[curr.posture] = (acc[curr.posture] || 0) + 1;
+      acc[curr.score] = (acc[curr.score] || 0) + 1;
       return acc;
     }, {});
 


### PR DESCRIPTION
## Summary
- correct posture aggregation to use `score`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e2be0ec48324b0a971e03516d0bc