### PR TITLE
Fix pig fertility stats key normalization

### DIFF
--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -100,10 +100,11 @@ router.get('/', async (req, res) => {
     }, {});
 
     // Process fertility data
-    const fertilityStats = pigFertilityData.reduce((acc, curr) => {
-      acc[curr._id.toLowerCase().replace(/\s+/g, '')] = curr.count;
-      return acc;
-    }, {});
+  const fertilityStats = pigFertilityData.reduce((acc, curr) => {
+    const key = curr._id.toLowerCase().replace(/[\s-]+/g, '');
+    acc[key] = curr.count;
+    return acc;
+  }, {});
 
     // Process heat status data
     const pigHeatStats = {
@@ -181,10 +182,10 @@ router.get('/', async (req, res) => {
       barnStats,
       stallStats,
       pigFertilityStats: {
-        InHeat: fertilityStats['in-heat'] || 0,
-        PreHeat: fertilityStats['pre-heat'] || 0,
+        InHeat: fertilityStats['inheat'] || 0,
+        PreHeat: fertilityStats['preheat'] || 0,
         Open: fertilityStats['open'] || 0,
-        ReadyToBreed: fertilityStats['ready-to-breed'] || 0,
+        ReadyToBreed: fertilityStats['readytobreed'] || 0,
       },
       farmBarnStallStats: {
         totalFarms: farmCount,

--- a/server/socket/stats.js
+++ b/server/socket/stats.js
@@ -123,7 +123,8 @@ const emitUpdatedStats = async (io) => {
     ]);
 
     const fertilityStats = pigFertilityAggregated.reduce((acc, curr) => {
-      acc[curr._id.toLowerCase().replace(/\\s+/g, '')] = curr.count;
+      const key = curr._id.toLowerCase().replace(/[\s-]+/g, '');
+      acc[key] = curr.count;
       return acc;
     }, {});
 


### PR DESCRIPTION
## Summary
- clean up fertility stat keys in stats.js files
- look up pig fertility stats using normalized keys

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854e2c33c008324ac46bd00f8fa5ecf