### PR TITLE
Refactor stats.js aggregation

### DIFF
--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -5,8 +5,7 @@ const mongoose = require('mongoose');
 // Get models directly from mongoose
 const Device = mongoose.model('Device');
 const PigBCS = mongoose.model('PigBCS'); // Changed from BCSData to PigBCS
-const PostureData = require('../models/PostureData'
-);
+const PostureData = require("../models/PostureData");
 const TemperatureData = mongoose.model('TemperatureData');
 const Pig = mongoose.model('Pig');
 const Farm = mongoose.model('Farm');
@@ -18,15 +17,12 @@ const PigHeatStatus = mongoose.model('PigHeatStatus');
 
 router.get('/', async (req, res) => {
   try {
-    // Execute all independent queries in parallel
     const [
-      devices,
-      pigs,
-      latestTemps,
-      bcsData,
-      postureData,
-      barns,
-      stalls,
+      deviceAgg,
+      latestTempsAgg,
+      bcsAgg,
+      postureAgg,
+      pigAggregations,
       pigHealthData,
       pigFertilityData,
       pigHeatStatusData,
@@ -34,13 +30,67 @@ router.get('/', async (req, res) => {
       barnCount,
       stallCount
     ] = await Promise.all([
-      Device.find({}),
-      Pig.find({}),
-      TemperatureData.find({}).sort({ timestamp: -1 }),
-      PigBCS.find({}).sort({ timestamp: -1 }), // Using PigBCS instead of BCSData
-      PostureData.find({}),
-      Barn.find({}),
-      Stall.find({}),
+      Device.aggregate([
+        {
+          $group: {
+            _id: null,
+            total: { $sum: 1 },
+            online: { $sum: { $cond: [{ $eq: ["$status", "online"] }, 1, 0] } },
+            averageTemperature: { $avg: "$temperature" }
+          }
+        }
+      ]),
+      TemperatureData.aggregate([
+        { $sort: { timestamp: -1 } },
+        { $group: { _id: "$deviceId", temperature: { $first: "$temperature" } } },
+        { $group: { _id: null, avgTemp: { $avg: "$temperature" } } }
+      ]),
+      PigBCS.aggregate([{ $group: { _id: null, avgScore: { $avg: "$score" } } }]),
+      PostureData.aggregate([{ $group: { _id: "$score", count: { $sum: 1 } } }]),
+      Pig.aggregate([
+        {
+          $facet: {
+            stats: [
+              { $group: { _id: null, total: { $sum: 1 }, avgAge: { $avg: "$age" } } }
+            ],
+            perBarn: [
+              { $group: { _id: "$currentLocation.barnId", totalPigs: { $sum: 1 } } },
+              {
+                $lookup: {
+                  from: "barns",
+                  localField: "_id",
+                  foreignField: "_id",
+                  as: "barn"
+                }
+              },
+              { $unwind: { path: "$barn", preserveNullAndEmptyArrays: true } },
+              { $project: { barnId: "$_id", name: "$barn.name", totalPigs: 1 } }
+            ],
+            perStall: [
+              { $group: { _id: "$currentLocation.stallId", totalPigs: { $sum: 1 } } },
+              {
+                $lookup: {
+                  from: "stalls",
+                  localField: "_id",
+                  foreignField: "_id",
+                  as: "stall"
+                }
+              },
+              { $unwind: { path: "$stall", preserveNullAndEmptyArrays: true } },
+              {
+                $lookup: {
+                  from: "barns",
+                  localField: "stall.barnId",
+                  foreignField: "_id",
+                  as: "barn"
+                }
+              },
+              { $unwind: { path: "$barn", preserveNullAndEmptyArrays: true } },
+              { $project: { stallId: "$_id", name: "$stall.name", barnId: "$barn._id", barnName: "$barn.name", totalPigs: 1 } }
+            ]
+          }
+        }
+      ]),
       PigHealthStatus.aggregate([
         { $sort: { timestamp: -1 } },
         { $group: { _id: "$pigId", status: { $first: "$status" } } },
@@ -59,53 +109,42 @@ router.get('/', async (req, res) => {
       Farm.countDocuments({}),
       Barn.countDocuments({}),
       Stall.countDocuments({})
-    ]);
+    );
 
-    // Calculate device stats
-    const onlineDevices = devices.filter(d => d.status === 'online').length;
-    const deviceUsage = devices.length > 0 
-      ? Math.round((onlineDevices / devices.length) * 100) 
-      : 0;
+    const deviceResult = deviceAgg[0] || {};
+    const totalDevices = deviceResult.total || 0;
+    const onlineDevices = deviceResult.online || 0;
+    const avgDeviceTemp = deviceResult.averageTemperature || 0;
+    const deviceUsage = totalDevices > 0 ? Math.round((onlineDevices / totalDevices) * 100) : 0;
 
-    // Calculate temperature stats
-    const avgDeviceTemp = devices.length > 0
-      ? devices.reduce((acc, d) => acc + (d.temperature || 0), 0) / devices.length
-      : 0;
-    
-    const avgTemp = latestTemps.length > 0
-      ? latestTemps.reduce((acc, curr) => acc + curr.temperature, 0) / latestTemps.length
-      : 0;
+    const avgTemp = latestTempsAgg[0]?.avgTemp || 0;
 
-    // Calculate BCS stats - using score instead of bcsScore
-    const avgBCS = bcsData.length > 0
-      ? bcsData.reduce((acc, curr) => acc + curr.score, 0) / bcsData.length
-      : 0;
+    const avgBCS = bcsAgg[0]?.avgScore || 0;
 
-    // Calculate posture stats
-    const postureCounts = postureData.reduce((acc, curr) => {
-      acc[curr.posture] = (acc[curr.posture] || 0) + 1;
-      return acc;
-    }, {});
-
-    const postureDistribution = Object.entries(postureCounts).map(([posture, count]) => ({
-      posture: Number(posture),
-      count,
-      percentage: postureData.length > 0 ? Math.round((count / postureData.length) * 100) : 0
+    const totalPostures = postureAgg.reduce((acc, p) => acc + p.count, 0);
+    const postureDistribution = postureAgg.map(p => ({
+      posture: Number(p._id),
+      count: p.count,
+      percentage: totalPostures > 0 ? Math.round((p.count / totalPostures) * 100) : 0
     }));
 
-    // Process health data
+    const pigAgg = pigAggregations[0] || { stats: [], perBarn: [], perStall: [] };
+    const pigStatsDoc = pigAgg.stats[0] || {};
+    const totalPigs = pigStatsDoc.total || 0;
+    const avgAge = pigStatsDoc.avgAge || 0;
+    const pigsPerBarn = pigAgg.perBarn;
+    const pigsPerStall = pigAgg.perStall;
+
     const healthStats = pigHealthData.reduce((acc, curr) => {
-      acc[curr._id.toLowerCase().replace(/\s+/g, '')] = curr.count;
+      acc[curr._id.toLowerCase()] = curr.count;
       return acc;
     }, {});
 
-    // Process fertility data
     const fertilityStats = pigFertilityData.reduce((acc, curr) => {
       acc[curr._id.toLowerCase().replace(/\s+/g, '')] = curr.count;
       return acc;
     }, {});
 
-    // Process heat status data
     const pigHeatStats = {
       totalOpen: pigHeatStatusData.find(h => h._id.toLowerCase() === 'open')?.count || 0,
       totalBred: pigHeatStatusData.find(h => h._id.toLowerCase() === 'bred')?.count || 0,
@@ -114,49 +153,23 @@ router.get('/', async (req, res) => {
       totalWeaning: pigHeatStatusData.find(h => h._id.toLowerCase() === 'weaning')?.count || 0,
     };
 
-    // Create maps for barn and stall data
-    const barnMap = new Map(barns.map(barn => [barn._id.toString(), barn.name]));
-    const stallMap = new Map(stalls.map(stall => [
-      stall._id.toString(), 
-      { name: stall.name, barnId: stall.barnId.toString() }
-    ]));
-
-    // Calculate pigs per barn and stall
-    const pigsPerBarn = await Pig.aggregate([
-      { $group: { _id: "$currentLocation.barnId", totalPigs: { $sum: 1 } } }
-    ]);
-
-    const pigsPerStall = await Pig.aggregate([
-      { $group: { _id: "$currentLocation.stallId", totalPigs: { $sum: 1 } } }
-    ]);
-
-    // Format barn stats
     const barnStats = {};
-    barns.forEach(barn => {
-      const barnId = barn._id.toString();
-      barnStats[barn.name] = pigsPerBarn.find(b => b._id.toString() === barnId)?.totalPigs || 0;
+    pigsPerBarn.forEach(b => {
+      barnStats[b.name || 'Unknown'] = b.totalPigs;
     });
 
-    // Format stall stats grouped by barn
     const stallStats = {};
-    barns.forEach(barn => {
-      const barnId = barn._id.toString();
-      stallStats[barn.name] = {};
-      
-      stalls
-        .filter(stall => stall.barnId.toString() === barnId)
-        .forEach(stall => {
-          const stallId = stall._id.toString();
-          stallStats[barn.name][stall.name] = 
-            pigsPerStall.find(s => s._id.toString() === stallId)?.totalPigs || 0;
-        });
+    pigsPerStall.forEach(s => {
+      const barnName = s.barnName || 'Unknown';
+      if (!stallStats[barnName]) stallStats[barnName] = {};
+      stallStats[barnName][s.name || 'Unknown'] = s.totalPigs;
     });
 
     // Prepare response - maintaining the exact same structure as before
     res.json({
       deviceStats: {
         onlineDevices,
-        totalDevices: devices.length,
+        totalDevices,
         deviceUsage,
         averageTemperature: Number(avgDeviceTemp.toFixed(1)),
         latestTemperatureStats: Number(avgTemp.toFixed(1))
@@ -166,16 +179,14 @@ router.get('/', async (req, res) => {
       },
       postureDistribution,
       pigStats: {
-        totalPigs: pigs.length,
-        averageAge: pigs.length 
-          ? Number((pigs.reduce((acc, p) => acc + (p.age || 0), 0) / pigs.length).toFixed(1)) 
-          : 0
+        totalPigs: totalPigs,
+        averageAge: Number((avgAge || 0).toFixed(1))
       },
       pigHealthStats: {
-        totalAtRisk: pigHealthData.find(h => h._id === 'at risk')?.count || 0,
-        totalHealthy: pigHealthData.find(h => h._id === 'healthy')?.count || 0,
-        totalCritical: pigHealthData.find(h => h._id === 'critical')?.count || 0,
-        totalNoMovement: pigHealthData.find(h => h._id === 'no movement')?.count || 0
+        totalAtRisk: healthStats['at risk'] || 0,
+        totalHealthy: healthStats['healthy'] || 0,
+        totalCritical: healthStats['critical'] || 0,
+        totalNoMovement: healthStats['no movement'] || 0
       },
       pigHeatStats,
       barnStats,


### PR DESCRIPTION
## Summary
- replace memory-heavy queries in `server/routes/stats.js` with aggregation pipelines
- compute pig, device and posture stats using single queries

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e2d48b4c8324b2ae4e383ff4e688