### PR TITLE
Fix pigId reference in posture upload

### DIFF
--- a/server/routes/upload/postureUpload.js
+++ b/server/routes/upload/postureUpload.js
@@ -74,7 +74,7 @@ router.post('/:pig_id', limiter, upload.single('file'), async (req, res) => {
 
             // Save the posture data
             const postureData = new PigPosture({
-              pigId: pig._id,
+              pigId: pig.pigId,
               timestamp: isoTimestamp,
               score: Posture,
             });


### PR DESCRIPTION
## Summary
- use pig.pigId for PigPosture entries instead of mongo `_id`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854e32dd6508324bf7ff3083eee38eb