### PR TITLE
Fix file removal in posture upload

### DIFF
--- a/server/routes/upload/postureUpload.js
+++ b/server/routes/upload/postureUpload.js
@@ -85,8 +85,12 @@ router.post('/:pig_id', limiter, upload.single('file'), async (req, res) => {
           }
         }
 
-        // Clean up the uploaded file
-        fs.unlinkSync(filePath);
+        // Clean up the uploaded file asynchronously to avoid blocking
+        try {
+          await fs.promises.unlink(filePath);
+        } catch (err) {
+          console.error('Error deleting uploaded file:', err);
+        }
 
         res.status(200).json({ message: 'Posture data uploaded successfully' });
       })


### PR DESCRIPTION
## Summary
- switch `fs.unlinkSync` to async `fs.promises.unlink` in posture upload route

## Testing
- `npm test` *(fails: Missing script "test")*
- `pnpm test` *(fails: couldn't fetch packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6854e33bc08883249115b700fb1c4844