### PR TITLE
Remove unused helper

### DIFF
--- a/server/routes/pig.js
+++ b/server/routes/pig.js
@@ -578,31 +578,6 @@ router.get('/:id/posture/latest', async (req, res) => {
   }
 })
 
-
-// Helper function to calculate date range based on a predefined range string
-// This function is kept for future use but is currently not used
-// eslint-disable-next-line no-unused-vars
-function calculateDateRange(range) {
-  const now = new Date();
-  let startDate = new Date();
-
-  switch (range) {
-    case '30-days':
-      startDate.setDate(now.getDate() - 30);
-      break;
-    case '90-days':
-      startDate.setDate(now.getDate() - 90);
-      break;
-    case '180-days':
-      startDate.setDate(now.getDate() - 180);
-      break;
-    default: // 365-days
-      startDate.setDate(now.getDate() - 365);
-  }
-
-  return { start: startDate };
-}
-
 // Create a new pig
 router.post('/', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- clean up unused `calculateDateRange` helper from pig routes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e365b2c88324af7154ac53f01705