### PR TITLE
Fix posture summary endpoint path

### DIFF
--- a/server/routes/pig.js
+++ b/server/routes/pig.js
@@ -942,7 +942,7 @@ router.get('/analytics/time-series', async (req, res) => {
 const dayjs = require('dayjs');
 
 // GET /api/pigs/:pigId/posture-summary?range=30
-router.get('/pigs/:pigId/posture-summary', async (req, res) => {
+router.get('/:pigId/posture-summary', async (req, res) => {
   try {
     const pigId = parseInt(req.params.pigId);
     let range = parseInt(req.query.range);


### PR DESCRIPTION
## Summary
- correct route for posture summary in `pig.js` so endpoint is `/api/pigs/:pigId/posture-summary`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854e3714f648324a75b055cd3771411