### PR TITLE
Fix posture page fetch

### DIFF
--- a/src/app/(main)/details/posture/page.tsx
+++ b/src/app/(main)/details/posture/page.tsx
@@ -11,17 +11,18 @@ export default function PosturePage() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        // This would need to be updated to fetch all posture data, not just for a specific pig
-        const response = await fetch('/api/pigs/posture')
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL || ''
+        const response = await fetch(`${apiUrl}/api/stats`)
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`)
         }
         const data = await response.json()
-        setPostureData(data)
-        setIsLoading(false)
+        setPostureData(data.postureDistribution || [])
+        setError(null)
       } catch (error) {
         console.error('Error fetching posture data:', error)
         setError('Failed to fetch posture data. Please try again later.')
+      } finally {
         setIsLoading(false)
       }
     }


### PR DESCRIPTION
## Summary
- fetch posture distribution from the `/api/stats` endpoint using `NEXT_PUBLIC_API_URL`
- only set error on failure and remove outdated comment

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558b6ba27c83248a453c4af091bdf9