### PR TITLE
Improve posture page UX

### DIFF
--- a/src/app/(main)/details/posture/page.tsx
+++ b/src/app/(main)/details/posture/page.tsx
@@ -20,7 +20,9 @@ export default function PosturePage() {
         setPostureData(data)
         setIsLoading(false)
       } catch (error) {
-        console.error('Error fetching posture data:', error)
+        if (process.env.NODE_ENV === 'development') {
+          console.error('Error fetching posture data:', error)
+        }
         setError('Failed to fetch posture data. Please try again later.')
         setIsLoading(false)
       }
@@ -51,8 +53,13 @@ export default function PosturePage() {
         Pig Posture Data
       </h1>
       <div className="mt-4 sm:mt-6 lg:mt-10">
-        <p className="mb-4">This page will display posture data for all pigs.</p>
-        {/* Add your posture data table or visualization here */}
+        {postureData.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No posture data available.</p>
+        ) : (
+          <pre className="whitespace-pre-wrap rounded-md bg-gray-100 p-4 text-xs dark:bg-gray-800">
+            {JSON.stringify(postureData, null, 2)}
+          </pre>
+        )}
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
- improve PosturePage data handling
  - only log errors in development
  - show a message when no posture data exists
  - render fetched data as JSON until real charts are added

## Testing
- `pnpm lint` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68558b83ade48324be52fd6494e5d2a2